### PR TITLE
do not double encode archive key

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function Obs (opts) {
     }
     var archive = self.drive.createArchive(undefined, { live: true })
     self.archive = archive
-    self.db.put('link', archive.key.toString('hex'), function (err) {
+    self.db.put('link', archive.key, function (err) {
       if (err) return self.emit('error')
       self.link = archive.key
       self.emit('link', archive.key)


### PR DESCRIPTION
i made hypercore throw an exception as well if the key is invalid (was silent before)
